### PR TITLE
Fix the expand/collapse chevrons on 3rd level nav

### DIFF
--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -166,6 +166,10 @@
         right: 0;
       }
 
+      .p-sidebar-nav__list {
+        position: relative;
+      }
+
       @media (min-width: 768px) {
         .theme__sidebar-toggle-button {
           background-image: url('https://assets.ubuntu.com/v1/39a96c62-navigation-menu-black.svg');


### PR DESCRIPTION
Used to be broken, like this:

![broken](https://assets.ubuntu.com/v1/1b0e47e2-broken-nav.png)

Now it looks like this:

![fixed](https://assets.ubuntu.com/v1/5b16ff6f-fixed.png)

QA
--

``` bash
python3 -m venv env3
source env3/bin/activate
pip install -e .
cd ..
cd maas-docs  # Or clone it if you don't have it
../documentation-builder/bin/documentation-builder --force
```

Now open `build/en/index.html` and check the third-level nav chevrons look fixed.