### PR TITLE
Disable URLize

### DIFF
--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -12,7 +12,6 @@ from markdown.extensions.meta import MetaExtension
 from markdown.extensions.tables import TableExtension
 from markdown.extensions.toc import TocExtension
 from markdown.extensions.codehilite import CodeHiliteExtension
-from mdx_urlize import UrlizeExtension
 from mdx_anchors_away import AnchorsAwayExtension
 from mdx_foldouts import makeExtension as FoldoutsExtension
 
@@ -49,8 +48,7 @@ markdown_extensions = [
     NotificationsExtension(),
     CodeHiliteExtension(),
     AnchorsAwayExtension(),
-    FoldoutsExtension(),
-    UrlizeExtension(),
+    FoldoutsExtension()
 ]
 
 


### PR DESCRIPTION
Because it breaks links in markup.

See #77.