### PR TITLE
Add external link functionality to navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 dist/
 .cache/
 .eggs/
+.vscode/
 pytestdebug.log
 *.snap
 parts/

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ To check your changes to documentation-builder, it's probably easiest to install
     python3 -m venv env3 && source env3/bin/activate  # Create encapsulated environment
     pip install -e .  # Install the module in editable mode
 
-    bin/documentation-builder --source-folder docs  # build the documentation-builder's own documentation
+    documentation-builder --source-folder docs  # build the documentation-builder's own documentation
     xdg-open build/en/index.html  # Open up the documentation page
 
 Watching for changes

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -4,3 +4,8 @@ navigation:
 
     - title: How to structure documentation
       location: structure.md
+
+    - title: Project repository
+      location: https://github.com/canonical-webteam/documentation-builder
+      external: true
+

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -256,7 +256,7 @@
                     {% if item.children %}
                     <h4 class="p-sidebar-nav__header {% if item.active %}is-active{% endif %}"><a href="{{ item.location }}">{{ item.title }}</a></h4>
                     {% else %}
-                    <a class="p-sidebar-nav__link {% if item.active %}is-active{% endif %}" href="{{ item.location }}">{{ item.title }}</a>
+                    <a class="p-sidebar-nav__link {% if item.external %}p-link--external {% endif %}{% if item.active %}is-active{% endif %}" href="{{ item.location }}">{{ item.title }}</a>
                     {% endif %}
                 {% else %}
                 <h4 class="p-sidebar-nav__header">{{ item.title }}</h4>
@@ -268,7 +268,7 @@
                     {% for child in item.children %}
                     <li>
                       {% if child.location %}
-                      <a class="p-sidebar-nav__link {% if child.active %}is-active{% endif %}" href="{{ child.location }}">
+                      <a class="p-sidebar-nav__link {% if child.external %}p-link--external {% endif %}{% if child.active %}is-active{% endif %}" href="{{ child.location }}">
                         {{ child.title }}
                       </a>
                       {% else %}
@@ -281,7 +281,7 @@
                           {% for grandchild in child.children %}
                           <li>
                             {% if grandchild.location %}
-                            <a class="p-sidebar-nav__link {% if grandchild.active %}is-active{% endif %}" href="{{ grandchild.location }}">
+                            <a class="p-sidebar-nav__link {% if grandchild.external %}p-link--external {% endif %}{% if grandchild.active %}is-active{% endif %}" href="{{ grandchild.location }}">
                               {{ grandchild.title }}
                             </a>
                             {% else %}


### PR DESCRIPTION
## Done
Developed the ability to add an external attribute to a navigation menu. Drive by fix in the Readme.

## QA
- Pull this branch
- Do the following:
``` bash
python3 -m venv env3 && source env3/bin/activate  # Create encapsulated environment
pip install -e .  # Install the module in editable mode

documentation-builder --source-folder docs  # build the documentation-builder's own documentation
xdg-open build/en/index.html  # Open up the documentation page
```
- Check that the menu item "Project repository" has an external class on it. 
- Check the others don't
- I will update the styling in a follow-up branch
