### PR TITLE
Hide the table of contents on tablet and small screens

### DIFF
--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -447,7 +447,7 @@
             </nav>
             {% endif %}
             {% if toc_items %}
-            <div class="p-aside__section">
+            <div class="p-aside__section u-hide--medium u-hide--small">
               <h4 class="p-aside__header">Contents</h4>
               <nav>
                 <ul class="p-toc">


### PR DESCRIPTION
## Done
Hide the table of contents on tablet and small screens to allow more room for body copy. This will change when UX have planned what to do on small screens.

Fixes https://github.com/vanilla-framework/vanilla-docs-theme/issues/34