### PR TITLE
Disable urlize

### DIFF
--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -12,7 +12,6 @@ from markdown.extensions.meta import MetaExtension
 from markdown.extensions.tables import TableExtension
 from markdown.extensions.toc import TocExtension
 from markdown.extensions.codehilite import CodeHiliteExtension
-from mdx_urlize import UrlizeExtension
 from mdx_anchors_away import AnchorsAwayExtension
 from mdx_foldouts import makeExtension as FoldoutsExtension
 
@@ -50,7 +49,6 @@ markdown_extensions = [
     CodeHiliteExtension(),
     AnchorsAwayExtension(),
     FoldoutsExtension(),
-    UrlizeExtension(),
 ]
 
 


### PR DESCRIPTION
## Done
The urlize module creates anchors links from urls in text. This is breaking `example-js`. Disabling for now.

## QA
- Pull this branch
- Run `python3 -m venv env3 && source env3/bin/activate`
- Run `pip install -e .`
- In the same session `cd` to your docs.vanillaframework.io` directory
- Run `./build-html`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/patterns/breadcrumbs
- Check that the example works
