### PR TITLE
Make table of contents by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,3 +71,13 @@ To run tests:
 
     ./setup.py test
 
+Debugging
+*********
+
+To run a specific test:
+
+.. code:: bash
+
+    ./setup.py test --addopts tests/test_operations.py::test_find_files
+
+You can debug tests by [adding a debugger to the code](https://www.safaribooksonline.com/blog/2014/11/18/intro-python-debugger/) and running the test again.

--- a/tests/fixtures/parse_markdown/plain_markdown.html
+++ b/tests/fixtures/parse_markdown/plain_markdown.html
@@ -2,7 +2,9 @@
 <head><title>A site</title></head>
 <body>
   <header><h1></h1></header>
-  
+  <nav><ul><li class="p-toc__item"><a class="p-toc__link" href="#usage">Usage</a></li>
+<li class="p-toc__item"><a class="p-toc__link" href="#further-reading">Further reading</a>
+</li></ul></nav>
   <main><h1 id="title">Title<a class="anchor" href="#title"></a></h1>
 <p>A description.</p>
 <h2 id="usage">Usage<a class="anchor" href="#usage"></a></h2>

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -236,11 +236,11 @@ def test_find_files():
     uppercase_files = files[3]
 
     assert new_files == [paths['new_file']]
-    assert modified_files == [
+    assert sorted(modified_files) == sorted([
         paths['unchanged_md'],
+        paths['unchanged_sub_md'],
         paths['modified_md'],
-        paths['unchanged_sub_md']
-    ]
+    ])
     assert unmodified_files == []
     assert uppercase_files == [paths['readme']]
 
@@ -257,10 +257,10 @@ def test_find_files():
     uppercase_files = files[3]
 
     assert new_files == [paths['new_file']]
-    assert modified_files == [
+    assert sorted(modified_files) == sorted([
+        path.join(source_dir, 'subdir', 'unchanged.md'),
         path.join(source_dir, 'subdir', 'modified_file.md'),
-        path.join(source_dir, 'subdir', 'unchanged.md')
-    ]
+    ])
     assert unmodified_files == [paths['unchanged_md']]
     assert uppercase_files == [paths['readme']]
 

--- a/ubuntudesign/documentation_builder/operations.py
+++ b/ubuntudesign/documentation_builder/operations.py
@@ -171,25 +171,23 @@ def parse_markdown(parser, template, filepath, metadata):
 
         metadata.update(markdown_meta)
 
-    if metadata.get('table_of_contents'):
-        toc_soup = BeautifulSoup(parser.toc, 'html.parser')
+    toc_soup = BeautifulSoup(parser.toc, 'html.parser')
 
-        # Get title list item (<h1>)
-        nav_item_strings = []
+    nav_item_strings = []
 
-        # Only get <h2> items, to avoid getting crazy
-        for item in toc_soup.select('.toc > ul > li > ul > li'):
-            for child in item('ul'):
-                child.extract()
+    # Only get <h2> items, to avoid getting crazy
+    for item in toc_soup.select('.toc > ul > li > ul > li'):
+        for child in item('ul'):
+            child.extract()
 
-            item['class'] = 'p-toc__item'
+        item['class'] = 'p-toc__item'
 
-            for anchor in item('a'):
-                anchor['class'] = 'p-toc__link'
+        for anchor in item('a'):
+            anchor['class'] = 'p-toc__link'
 
-            nav_item_strings.append(str(item))
+        nav_item_strings.append(str(item))
 
-        metadata['toc_items'] = "\n".join(nav_item_strings)
+    metadata['toc_items'] = "\n".join(nav_item_strings)
 
     return template.render(metadata)
 


### PR DESCRIPTION
## Done
Make the table of contents opt out. Update some failing tests.

## QA
- Pull this branch
- `python3 -m venv env3 && source env3/bin/activate`
- `pip install -e .`
- `rm -rf build && documentation-builder --source-folder docs`
- `xdg-open build/en/index.html`
- Check the index has a TOC
- Go to How to structure documentation page
- See there is a TOC too

## Details
Fixes https://github.com/canonical-webteam/documentation-builder/issues/50