### PR TITLE
Allow custom footer text/links and remove leftover Vanilla markup

### DIFF
--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -254,7 +254,18 @@
         <footer class="p-footer" role="contentinfo">
           <div class="p-content__row u-no-margin--left">
             <div class="col-12">
-              <p>&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+              <p>
+                {% if site_footer_text %}{{ site_footer_text }}
+                {% else %}&copy; 2018 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
+                {% endif %}
+              </p>
+              {% if site_footer_links %}
+              <ul class="p-inline-list--middot">
+                {% for link in site_footer_links %}
+                <li class="p-inline-list__item"><a href="{{ link.location }}">{{ link.title }}</a></li>
+                {% endfor %}
+              </ul>
+              {% endif %}
             </div>
           </div>
         </footer>
@@ -287,7 +298,12 @@
       var links = document.querySelectorAll('a');
       links.forEach(function(link) {
         var parentClass = link.parentNode.classList;
-        var ignoreNav = !(parentClass.contains('p-navigation__logo') || parentClass.contains('p-navigation__link') || parentClass.contains('p-sidebar-nav__item'));
+        var ignoreNav = !(
+          parentClass.contains('p-navigation__logo') ||
+          parentClass.contains('p-navigation__link') ||
+          parentClass.contains('p-sidebar-nav__item') ||
+          parentClass.contains('p-inline-list__item')
+        );
         if (link.hostname && link.hostname != location.hostname && ignoreNav) {
           link.className += ' p-link--external';
         }

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -226,17 +226,6 @@
               </li>
               {% endfor %}
             </ul>
-            <ul class="p-sidebar-nav__list u-hide" id="docs-list-sorted">
-              {% for item in navigation %}{% for child in item.children %}
-                <li class="p-sidebar-nav__item">
-                  {% if child.location %}
-                    <a class="p-link--soft" href="{{ child.location }}">{{ child.title }}</a>
-                  {% else %}
-                    {{ child.title }}
-                  {% endif %}
-                </li>
-              {% endfor %}{% endfor %}
-            </ul>
           </nav>
         </div>
       </aside>
@@ -260,7 +249,7 @@
                 {% endif %}
               </p>
               {% if site_footer_links %}
-              <ul class="p-inline-list--middot">
+              <ul class="p-inline-list--middot u-no-margin--bottom">
                 {% for link in site_footer_links %}
                 <li class="p-inline-list__item"><a href="{{ link.location }}">{{ link.title }}</a></li>
                 {% endfor %}


### PR DESCRIPTION
## Done

- Edited template so that if certain site metadata is passed through (`site_footer_text` and `site_footer_links`) you can customise the footer.
- Removed sorted list markup that was leftover from stealing the code from Vanilla docs

## QA

- Pull code
- Copy `ubuntudesign/documentation_builder/resources/template.html` over to `docs/template.html`
- `./run` and check that the footer looks the same as before (default canonical one)
- Now open `docs/metadata.yaml` and paste in the following code:
``` yaml
site_footer_text: 'Custom footer text'
site_footer_links:
  - title: 'Link 1'
    location: /link1

  - title: 'Link 2'
    location: /link2
```
- `./run` again and check that the footer now has a different footer