### PR TITLE
Add Juju homepage example

### DIFF
--- a/docs/en/homepage-examples/juju-example.md
+++ b/docs/en/homepage-examples/juju-example.md
@@ -1,0 +1,90 @@
+---
+title: Juju template
+homepage: true
+---
+
+<div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/bd1d8c1d-juju-suru-blue-background.png')">
+    <div class="p-content__row">
+        <h1>What is Juju</h1>
+        <p class="p-heading--four">Juju is an open source application modeling tool. It allows you to deploy, configure, scale and operate your software on public and private clouds.</p>
+    </div>
+</div>
+<div class="p-strip">
+    <div class="p-content__row">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting started</h2>
+                <p>Juju works with public cloud, private clouds, and locally with LXD.</p>
+                <p><a href="#">Getting started with Juju&nbsp;&rsaquo;</a></p>
+            </div>
+            <div class="col-6 u-align--right">
+                <img style="border: 0" src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg">
+            </div>
+        </div>
+        <hr class="is-deep">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>What's new</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a href="#">Juju audit logging&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="#">Using Juju locally (LXD)&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="#">What's new in 2.3&nbsp;&rsaquo;</a></li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <h2>Explore Juju</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a href="#">Install Juju&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="#">Working with controllers and models&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="#">Concepts and terms&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="#">Working with users&nbsp;&rsaquo;</a></li>
+                </ul>
+            </div>
+        </div>
+        <hr class="is-deep">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting support</h2>
+                <ul class="p-list is-split">
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/039628d5-picto-community-orange.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Community</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/fa38eb81-picto-business-midaubergine.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Professional support</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/4ef84d88-picto-quote-warmgrey.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Blog</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/1ad274f9-rocket-chat.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Rocket chat</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/422b612c-picto-forum-warmgrey.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Forum</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/d3ae9c8e-irc-icon-circle.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Freenode</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <h2>Contribute</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a class="p-link--external" href="#">Help improve Juju</a></li>
+                    <li class="p-list__item--deep"><a class="p-link--external" href="#">Help improve the documentation</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -11,8 +11,12 @@ navigation:
         - title: Base template
           location: homepage-examples/default.md
 
+        - title: Juju
+          location: homepage-examples/juju-example.md
+
         - title: Snap Enterprise Proxy
           location: homepage-examples/enterprise-proxy-example.md
+
 
     - title: Project repository
       location: https://github.com/canonical-webteam/documentation-builder


### PR DESCRIPTION
## Done

- Added Juju homepage example to documentation-builder docs

## QA

## QA

- Pull code
- Open `docs/metadata.yaml` and replace contents with:
``` yaml
site_title: Juju documentation
site_logo_url: https://assets.ubuntu.com/v1/9afc1e35-juju_white-orange_hex.svg
site_favicon: https://assets.ubuntu.com/v1/751b08fb-favicon.ico
site_remove_navigation_title: true

site_navigation:
  - title: Store
    location: https://jujucharms.com/store

  - title: How it works
    location: https://jujucharms.com/how-it-works

  - title: JAAS
    location: https://jujucharms.com/jaas

  - title: Experts
    location: https://jujucharms.com/experts

  - title: Community
    location: https://jujucharms.com/community

  - title: Docs
    location: /

  - title: Try the beta
    location: https://jujucharms.com/new/?dd=cs:bundle/canonical-kubernetes

site_navigation_colors:
  background: '#022935'
  border: '#33535d'
  hover: '#011e26'
  text: '#fff'

site_footer_links:
  - title: Docs
    location: https://docs.jujucharms.com/getting-started

  - title: Community
    location: https://jujucharms.com/community

  - title: Blog
    location: https://jujucharms.com/community/blog

  - title: Install Juju
    location: https://jujucharms.com/docs
```
- Run `./run`
- Go to http://0.0.0.0:8000/en/homepage-examples/juju-example
- Check that it matches the [design](https://raw.githubusercontent.com/ubuntudesign/vanilla-design/master/Templates/Documentation-homepage/003%20Juju%20template/juju-documentation-home-template.png)

## Screenshot

![0 0 0 0_8000_en_homepage-examples_juju-example 1](https://user-images.githubusercontent.com/25733845/41469083-f89287f8-70a3-11e8-98e0-d80de2d547ef.png)
