### PR TITLE
Add MAAS homepage example

### DIFF
--- a/docs/en/homepage-examples/maas-example.md
+++ b/docs/en/homepage-examples/maas-example.md
@@ -1,0 +1,80 @@
+---
+title: MAAS example
+homepage: true
+---
+
+<div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/a328d904-MAAS-background-desktop-large-screen.png')">
+    <div class="p-content__row">
+        <div class="col-8">
+            <h1>MAAS Documentation</h1>
+            <p>MAAS is Metal As A Service. It lets you treat physical servers like virtual machines (instances) in the cloud. Rather than having to manage each server individually, MAAS turns your bare metal into an elastic cloud-like resource.</p>
+        </div>
+    </div>
+</div>
+<div class="p-strip">
+    <div class="p-content__row">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting started</h2>
+                <div>
+                    <p>What MAAS offers</p>
+                    <p><a href="#">What is MAAS?&nbsp;&rsaquo;</a></p>
+                </div>
+                <div>
+                    <p>How MAAS works</p>
+                    <p><a href="#">Find out more&nbsp;&rsaquo;</a></p>
+                </div>
+                <div>
+                    <p>Install MAAS</p>
+                    <p><a href="#">Installation&nbsp;&rsaquo;</a></p>
+                </div>
+            </div>
+            <div class="col-6">
+                <img style="max-height: 20rem;" src="https://assets.ubuntu.com/v1/be6bd70c-Keep+an+eye+on+your+hardware+-+hardware+tests+list.jpg">
+            </div>
+        </div>
+        <hr class="is-deep">
+        <div>
+            <h2>What's new</h2>
+            <ul class="p-list">
+                <li class="p-list__item"><a href="#">MAAS 2.3 is out!&nbsp;&rsaquo;</a></li>
+                <li class="p-list__item"><a href="#">MAAS for the home&nbsp;&rsaquo;</a></li>
+                <li class="p-list__item"><a href="#">Create KVM pods with MAAS&nbsp;&rsaquo;</a></li>
+                <li class="p-list__item"><a href="#">Explore MAAS&nbsp;&rsaquo;</a></li>
+            </ul>
+        </div>
+        <hr class="is-deep">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting support</h2>
+                <ul class="p-list">
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/fa38eb81-picto-business-midaubergine.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Professional support</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Blog</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/d3ae9c8e-irc-icon-circle.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">IRC</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <h2>Contribute</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a class="p-link--external" href="#">Contributing guides</a></li>
+                    <li class="p-list__item--deep"><a class="p-link--external" href="#">Ways you can contribute</a></li>
+                    <li class="p-list__item"><a class="p-link--external" href="#">Push some code</a></li>
+                    <li class="p-list__item--deep"><a class="p-link--external" href="#">File an issue</a></li>
+                    <li class="p-list__item"><a class="p-link--external" href="#">Write some docs</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -11,12 +11,14 @@ navigation:
         - title: Base template
           location: homepage-examples/default.md
 
+        - title: MAAS
+          location: homepage-examples/maas-example.md
+
         - title: Juju
           location: homepage-examples/juju-example.md
 
         - title: Snap Enterprise Proxy
           location: homepage-examples/enterprise-proxy-example.md
-
 
     - title: Project repository
       location: https://github.com/canonical-webteam/documentation-builder


### PR DESCRIPTION
## Done

- Added MAAS homepage example to documentation-builder docs

## QA

- Pull code
- Open `docs/metadata.yaml` and replace contents with:
``` yaml
site_title: MAAS documentation
site_logo_url: 'https://assets.ubuntu.com/v1/4fac1d52-MAAS-Logo.svg'
site_favicon: 'https://assets.ubuntu.com/v1/5922a009-maas-favicon-32px.png'
site_remove_navigation_title: true

site_navigation:
  - title: Install
    location: https://maas.io/install

  - title: Architecture
    location: https://maas.io/how-it-works

  - title: Tour
    location: https://maas.io/tour

  - title: Docs
    location: /
    selected: true

  - title: Contact us
    location: https://maas.io/contact-us

site_navigation_colors:
  active: '#e95420'
  background: '#000'
  border: '#666'
  hover: '#e95420'
  text: '#fff'

site_footer_links:
  - title: 'Legal information'
    location: https://www.ubuntu.com/legal
    
  - title: 'Report a bug on this site'
    location: https://github.com/CanonicalLtd/maas-docs/issues/new
```
- Run `./run`
- Go to http://0.0.0.0:8000/en/homepage-examples/maas-example
- Check that it matches the [design](https://raw.githubusercontent.com/ubuntudesign/vanilla-design/master/Templates/Documentation-homepage/004%20MAAS%20template/maas-documentation-home-template.png)

## Screenshot

![0 0 0 0_8000_en_homepage-examples_maas-example 1](https://user-images.githubusercontent.com/25733845/41498739-90bc7e44-716c-11e8-88d8-14b8a8d0af3e.png)


