### PR TITLE
Add conjure up homepage example

### DIFF
--- a/docs/en/homepage-examples/conjure-up-example.md
+++ b/docs/en/homepage-examples/conjure-up-example.md
@@ -1,0 +1,60 @@
+---
+title: conjure-up example
+homepage: true
+---
+
+<div class="p-strip--image" style="background-image: url('https://assets.ubuntu.com/v1/4a3a6943-background.png')">
+    <div class="p-content__row">
+        <div class="col-8">
+            <h1>What is conjure-up</h1>
+            <p>Conjure-up is a tool to deploy complex applications with the minimum of fuss. Working on top of technologies like Juju and MAAS, you can go from nothing to a fully working OpenStack, hadoop, kubernetes and more in minutes</p>
+            <p>Discover more in the <a href="#">FAQ&nbsp;&rsaquo;</a></p>
+        </div>
+    </div>
+</div>
+<div class="p-strip">
+    <div class="p-content__row">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting started</h2>
+                <h3>Deploy the Canonical Distribution of Kubernetes</h3>
+                <p>Try this guide to see how easy deploying complex applications can be!</p>
+                <a href="#">Quick link&nbsp;&rsaquo;</a>
+            </div>
+            <div class="col-6">
+                <img style="max-height: 20rem; padding: 1rem 5rem;" src="https://assets.ubuntu.com/v1/b108a74b-kubernetes-1-left.png">
+            </div>
+        </div>
+        <hr class="is-deep">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting support</h2>
+                <ul class="p-list">
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/d3ae9c8e-irc-icon-circle.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Find us on irc at #conjure-up</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/4d7dbd0c-icon-settings.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Check through the troubleshooting guide</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/ebbde87e-picto-email-warmgrey.png');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="#">Join the mailing list</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <h2>Contribute</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a class="p-link--external" href="#">Improve the docs</a></li>
+                    <li class="p-list__item--deep"><a class="p-link--external" href="#">Make a spell</a></li>
+                    <li class="p-list__item"><a class="p-link--external" href="#">Hack on conjure-up</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -17,6 +17,9 @@ navigation:
         - title: Juju
           location: homepage-examples/juju-example.md
 
+        - title: conjure-up
+          location: homepage-examples/conjure-up-example.md
+
         - title: Snap Enterprise Proxy
           location: homepage-examples/enterprise-proxy-example.md
 


### PR DESCRIPTION
## Done

- Added conjure-up homepage example to documentation-builder docs

## QA

- Pull code
- Open `docs/metadata.yaml` and replace contents with:
``` yaml
site_title: Conjure-up documentation
site_logo_url: https://assets.ubuntu.com/v1/8c237d84-conjure-up-logo-black.svg
site_favicon: https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png
site_remove_navigation_title: true

site_navigation:
  - title: User manual
    location: /

  - title: Developer manual
    location: /dev-manual

site_footer_links:
  - title: 'Legal information'
    location: https://www.ubuntu.com/legal
    
  - title: 'Report a bug on this site'
    location: https://github.com/CanonicalLtd/maas-docs/issues/new
```
- Run `./run`
- Go to http://0.0.0.0:8000/en/homepage-examples/conjure-up-example
- Check that it matches the [design](https://raw.githubusercontent.com/ubuntudesign/vanilla-design/master/Templates/Documentation-homepage/002%20conjure-up%20template/conjure-up-documentation-home-template.png)

## Screenshot

![0 0 0 0_8000_en_homepage-examples_conjure-up-example 1](https://user-images.githubusercontent.com/25733845/41498973-094ef55e-7171-11e8-970c-34c0e5c13e0d.png)

