### PR TITLE
Add canonical url to template

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -590,9 +590,18 @@ def test_set_active_navigation_items():
 def test_version_paths():
     function_fixtures = path.join(fixtures_path, 'version_paths')
     version_branches = {
-        '1.8': {'base_directory': path.join(function_fixtures, '1.8')},
-        '1.9': {'base_directory': path.join(function_fixtures, '1.9')},
-        'master': {'base_directory': path.join(function_fixtures, 'master')}
+        '1.8': {
+            'base_directory': path.join(function_fixtures, '1.8'),
+            'order': 2
+        },
+        '1.9': {
+            'base_directory': path.join(function_fixtures, '1.9'),
+            'order': 1
+        },
+        'master': {
+            'base_directory': path.join(function_fixtures, 'master'),
+            'order': 0
+        }
     }
     relative_filepath = path.join('en', 'subfolder', 'index.md')
 
@@ -603,11 +612,12 @@ def test_version_paths():
         relative_filepath=relative_filepath
     )
 
-    assert paths[0] == {'name': '1.8', 'path': None}
-    assert paths[1] == {'name': '1.9', 'path': ''}
+    assert paths[0] == {'name': '1.8', 'path': None, 'latest': False}
+    assert paths[1] == {'name': '1.9', 'path': '', 'latest': False}
     assert paths[2] == {
         'name': 'master',
-        'path': '../../../master/en/subfolder/index.md'
+        'path': '../../../master/en/subfolder/index.md',
+        'latest': True
     }
 
 

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -234,6 +234,10 @@ class Builder():
                     relative_filepath
                 )
 
+                for version in metadata['versions']:
+                    if version['latest']:
+                        metadata['latest_version'] = version['path']
+
             html = parse_markdown(
                 self.parser,
                 self.template,

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -15,6 +15,7 @@
     <meta charset="UTF-8" />
     <title>{{ title }} | {{ site_title if site_title else 'Documentation' }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="canonical" href="{{ latest_version }}" />
     <link rel="icon" href="{{ site_favicon }}" type="image/x-icon" />
     <style>
       /* Vanilla 1.7.1 + docs styling*/


### PR DESCRIPTION
# Summary 

Fixes #96 
Add canonical url to the template when the url is provided by the flask app that is serving the files

# QA

- Build a documentation and make sure that the header has a canonical url
- build maas-docs
- Inspect HTML and make sure pages have a canonical url in the `<head>`
- It should also work for pages that has been removed in the latest version, the canonical address should be the latest version that the documentation has. (example: https://docs.maas.io/2.0/en/installconfig-nodes-deploy )