### PR TITLE
Add base canonical passed to the templates

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -14,6 +14,7 @@ from jinja2 import Template
 # Local modules
 from ubuntudesign.documentation_builder.operations import (
     compile_metadata,
+    convert_path_to_html,
     copy_media,
     find_files,
     find_metadata,
@@ -612,13 +613,33 @@ def test_version_paths():
         relative_filepath=relative_filepath
     )
 
-    assert paths[0] == {'name': '1.8', 'path': None, 'latest': False}
-    assert paths[1] == {'name': '1.9', 'path': '', 'latest': False}
+    assert paths[0] == {
+        'name': '1.8',
+        'path': None,
+        'latest': False,
+    }
+    assert paths[1] == {
+        'name': '1.9',
+        'path': '',
+        'latest': False,
+    }
     assert paths[2] == {
         'name': 'master',
         'path': '../../../master/en/subfolder/index.md',
-        'latest': True
+        'latest': True,
     }
+
+
+def test_convert_path_to_html():
+    path = "path/to/index.md"
+
+    new_path = convert_path_to_html(path)
+    assert new_path == 'path/to/'
+
+    path = "path/to/toto.md"
+
+    new_path = convert_path_to_html(path)
+    assert new_path == 'path/to/toto'
 
 
 def test_write_html():

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -27,7 +27,8 @@ from .operations import (
     prepare_version_branches,
     set_active_navigation_items,
     version_paths,
-    write_html
+    write_html,
+    convert_path_to_html
 )
 from .extensions import NotificationsExtension
 
@@ -236,7 +237,11 @@ class Builder():
 
                 for version in metadata['versions']:
                     if version['latest']:
-                        metadata['latest_version'] = version['path']
+                        metadata['relative_canonical'] = version['path']
+                        metadata['base_canonical'] = convert_path_to_html(
+                            version['name'] + '/' + relative_filepath)
+            else:
+                metadata['base_canonical'] = convert_path_to_html(filepath)
 
             html = parse_markdown(
                 self.parser,

--- a/ubuntudesign/documentation_builder/operations.py
+++ b/ubuntudesign/documentation_builder/operations.py
@@ -417,6 +417,13 @@ def version_paths(
     return version_filepaths
 
 
+def convert_path_to_html(path):
+    path = path.replace('.md', '')
+    path = path.replace('index', '')
+
+    return path
+
+
 def write_html(html, output_filepath):
 
     """

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -15,7 +15,7 @@
     <meta charset="UTF-8" />
     <title>{{ title }} | {{ site_title if site_title else 'Documentation' }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="canonical" href="{{ relative_canonical }}" />
+    {% if relative_canonical %}<link rel="canonical" href="{{ relative_canonical }}" />{% endif %}
     <link rel="icon" href="{{ site_favicon }}" type="image/x-icon" />
     <style>
       /* Vanilla 1.7.1 + docs styling*/

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -15,7 +15,7 @@
     <meta charset="UTF-8" />
     <title>{{ title }} | {{ site_title if site_title else 'Documentation' }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="canonical" href="{{ latest_version }}" />
+    <link rel="canonical" href="{{ relative_canonical }}" />
     <link rel="icon" href="{{ site_favicon }}" type="image/x-icon" />
     <style>
       /* Vanilla 1.7.1 + docs styling*/


### PR DESCRIPTION
# Summary

Add `base_canonical` that can be passed to the templates

# QA 

On maas docs copy template from resources
add line: `<link rel="canonical" href="https://docs.maas.io/{{ base_canonical }}" />` in the header
run: 
```
documentation-builder --base-directory . --output-path templates  --template-path template.html --output-media-path 'static/media' --media-url '/static/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.maas.io' --search-url 'https://docs.ubuntu.com/search' --search-placeholder 'Search MAAS docs' --no-link-extensions --build-version-branches --site-root https://maas.io/
```

Make sure canonical url is right.